### PR TITLE
feat: add Sources Page

### DIFF
--- a/src/components/sources/DocumentModal.tsx
+++ b/src/components/sources/DocumentModal.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+  Text,
+  Link,
+  UnorderedList,
+  ListItem,
+  Box,
+  VStack,
+} from "@chakra-ui/react";
+
+interface DocumentModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  document: Record<string, any> | null;
+  isLoading: boolean;
+  isError: boolean;
+  error?: string;
+}
+
+const formatValue = (value: any): string => {
+  if (typeof value === "string") {
+    return value;
+  } else if (typeof value === "number" || typeof value === "boolean") {
+    return value.toString();
+  } else if (value instanceof Date) {
+    return value.toISOString();
+  }
+  return "";
+};
+
+const RenderField = ({ name, value }: { name: string; value: any }) => {
+  if (Array.isArray(value)) {
+    return (
+      <Box mb={2}>
+        <Text fontWeight="bold">{name}:</Text>
+        <UnorderedList ml={5}>
+          {value.map((item, index) => (
+            <ListItem key={index}>
+              {typeof item === "object" ? (
+                <RenderObject object={item} />
+              ) : (
+                formatValue(item)
+              )}
+            </ListItem>
+          ))}
+        </UnorderedList>
+      </Box>
+    );
+  } else if (typeof value === "object" && value !== null) {
+    return (
+      <Box mb={2}>
+        <Text fontWeight="bold">{name}:</Text>
+        <Box ml={4}>
+          <RenderObject object={value} />
+        </Box>
+      </Box>
+    );
+  } else {
+    return (
+      <Text mb={2}>
+        <Text as="span" fontWeight="bold">
+          {name}:
+        </Text>{" "}
+        {formatValue(value)}
+      </Text>
+    );
+  }
+};
+
+const RenderObject = ({ object }: { object: Record<string, any> }) => {
+  return (
+    <VStack align="stretch" spacing={2}>
+      {Object.entries(object).map(([key, value]) => (
+        <RenderField key={key} name={key} value={value} />
+      ))}
+    </VStack>
+  );
+};
+
+const DocumentModal: React.FC<DocumentModalProps> = ({
+  isOpen,
+  onClose,
+  document,
+  isLoading,
+  isError,
+  error,
+}) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="xl" scrollBehavior="inside">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>{document?.title || "Document Details"}</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          {isLoading && <Text>Loading document content...</Text>}
+          {isError && (
+            <Text color="red.500">Error loading document: {error}</Text>
+          )}
+          {!isLoading && !isError && document && (
+            <VStack align="stretch" spacing={4}>
+              {document.url && (
+                <Link
+                  href={document.url}
+                  isExternal
+                  color="blue.500"
+                  _hover={{ textDecoration: "underline" }}
+                >
+                  {document.url}
+                </Link>
+              )}
+              <RenderObject object={document} />
+            </VStack>
+          )}
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default DocumentModal;

--- a/src/components/sources/Documents.tsx
+++ b/src/components/sources/Documents.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from "react";
+import { FaEye } from "react-icons/fa";
+
 import { useSourceDocuments } from "@/hooks/useSourceDocuments";
+import { useDocumentContent } from "@/hooks/useDocumentContent";
 import { formatTimeAgo } from "@/utils/dateUtils";
+import DocumentModal from "./DocumentModal";
 
 interface SourceDocumentsProps {
   domain: string;
@@ -19,12 +23,25 @@ const Documents: React.FC<SourceDocumentsProps> = ({ domain }) => {
   const [page, setPage] = useState(1);
   const { sourceDocuments, total, isLoading, isError, error } =
     useSourceDocuments(domain, page);
+  const [selectedDocumentUrl, setSelectedDocumentUrl] = useState<string | null>(
+    null
+  );
+  const {
+    documentContent,
+    isLoading: isContentLoading,
+    isError: isContentError,
+    error: contentError,
+  } = useDocumentContent(selectedDocumentUrl);
 
   if (isLoading) return <div>Loading source documents...</div>;
   if (isError)
     return <div>Error loading source documents: {error.message}</div>;
 
   const totalPages = Math.ceil(total / 10);
+
+  const handleViewDocument = (url: string) => {
+    setSelectedDocumentUrl(url);
+  };
 
   return (
     <div className="mt-4">
@@ -42,6 +59,7 @@ const Documents: React.FC<SourceDocumentsProps> = ({ domain }) => {
               <th className="px-4 py-2 border-b border-custom-stroke whitespace-nowrap">
                 Indexed At
               </th>
+              <th className="w-10 px-2 py-2 border-b border-custom-stroke"></th>
             </tr>
           </thead>
           <tbody>
@@ -80,6 +98,15 @@ const Documents: React.FC<SourceDocumentsProps> = ({ domain }) => {
                     </span>
                   </div>
                 </td>
+                <td className="w-10 px-2 py-2 border-b border-custom-stroke text-center">
+                  <button
+                    onClick={() => handleViewDocument(doc.url)}
+                    className="text-custom-accent hover:text-custom-accent-dark"
+                    title="View document"
+                  >
+                    <FaEye className="w-5 h-5 inline-block" />
+                  </button>
+                </td>
               </tr>
             ))}
           </tbody>
@@ -104,6 +131,14 @@ const Documents: React.FC<SourceDocumentsProps> = ({ domain }) => {
           Next
         </button>
       </div>
+      <DocumentModal
+        isOpen={!!selectedDocumentUrl}
+        onClose={() => setSelectedDocumentUrl(null)}
+        document={documentContent}
+        isLoading={isContentLoading}
+        isError={isContentError}
+        error={contentError?.message}
+      />
     </div>
   );
 };

--- a/src/components/sources/Documents.tsx
+++ b/src/components/sources/Documents.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from "react";
+import { useSourceDocuments } from "@/hooks/useSourceDocuments";
+import { formatTimeAgo } from "@/utils/dateUtils";
+
+interface SourceDocumentsProps {
+  domain: string;
+}
+
+const trimUrl = (url: string, domain: string): string => {
+  const domainPattern = new RegExp(
+    `^(https?:\/\/)?(www\.)?${domain.replace(".", ".")}/?`,
+    "i"
+  );
+  const trimmed = url.replace(domainPattern, "");
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+};
+
+const Documents: React.FC<SourceDocumentsProps> = ({ domain }) => {
+  const [page, setPage] = useState(1);
+  const { sourceDocuments, total, isLoading, isError, error } =
+    useSourceDocuments(domain, page);
+
+  if (isLoading) return <div>Loading source documents...</div>;
+  if (isError)
+    return <div>Error loading source documents: {error.message}</div>;
+
+  const totalPages = Math.ceil(total / 10);
+
+  return (
+    <div className="mt-4">
+      <h3 className="text-lg font-semibold mb-2">Documents for {domain}</h3>
+      <div className="overflow-x-auto">
+        <table className="min-w-full border border-custom-stroke">
+          <thead>
+            <tr className="bg-custom-hover-state dark:bg-custom-hover-primary">
+              <th className="px-4 py-2 border-b border-custom-stroke whitespace-nowrap">
+                Title
+              </th>
+              <th className="px-4 py-2 border-b border-custom-stroke whitespace-nowrap">
+                URL
+              </th>
+              <th className="px-4 py-2 border-b border-custom-stroke whitespace-nowrap">
+                Indexed At
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {sourceDocuments?.map((doc, index) => (
+              <tr
+                key={index}
+                className={
+                  index % 2 === 0
+                    ? "bg-custom-hover-state dark:bg-custom-hover-primary"
+                    : "bg-custom-background"
+                }
+              >
+                <td className="px-4 py-2 border-b border-custom-stroke max-w-xs">
+                  <div className="truncate" title={doc.title}>
+                    {doc.title}
+                  </div>
+                </td>
+                <td className="px-4 py-2 border-b border-custom-stroke">
+                  <div className="truncate max-w-md">
+                    <a
+                      href={doc.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-custom-accent hover:underline"
+                      title={doc.url}
+                    >
+                      {trimUrl(doc.url, domain)}
+                    </a>
+                  </div>
+                </td>
+                <td className="px-4 py-2 border-b border-custom-stroke whitespace-nowrap">
+                  <div className="group relative inline-block">
+                    <span>{formatTimeAgo(doc.indexed_at)}</span>
+                    <span className="invisible group-hover:visible absolute left-0 -translate-x-1/2 bottom-full mb-2 px-2 py-1 text-sm bg-custom-black text-custom-white rounded opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap z-10">
+                      {new Date(doc.indexed_at).toLocaleString()}
+                    </span>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="mt-4 flex justify-between items-center">
+        <button
+          onClick={() => setPage((p) => Math.max(1, p - 1))}
+          disabled={page === 1}
+          className="px-4 py-2 bg-custom-button text-custom-white rounded disabled:opacity-50"
+        >
+          Previous
+        </button>
+        <span>
+          Page {page} of {totalPages}
+        </span>
+        <button
+          onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          disabled={page === totalPages}
+          className="px-4 py-2 bg-custom-button text-custom-white rounded disabled:opacity-50"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Documents;

--- a/src/hooks/useDocumentContent.ts
+++ b/src/hooks/useDocumentContent.ts
@@ -1,0 +1,39 @@
+import { useQuery } from "@tanstack/react-query";
+
+interface DocumentContent {
+  title: string;
+  url: string;
+  content: string;
+  indexed_at: string;
+}
+
+const fetchDocumentContent = async (url: string): Promise<DocumentContent> => {
+  const response = await fetch("/api/elasticSearchProxy/getDocumentContent", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ url }),
+  });
+  const data = await response.json();
+  if (!data.success) throw new Error(data.message);
+  return data.data;
+};
+
+export const useDocumentContent = (url: string) => {
+  const { data, isLoading, isError, error } = useQuery<DocumentContent, Error>({
+    queryKey: ["documentContent", url],
+    queryFn: () => fetchDocumentContent(url),
+    enabled: !!url,
+    cacheTime: Infinity,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    documentContent: data,
+    isLoading,
+    isError,
+    error,
+  };
+};

--- a/src/hooks/useSourceDocuments.ts
+++ b/src/hooks/useSourceDocuments.ts
@@ -1,0 +1,47 @@
+import { useQuery } from "@tanstack/react-query";
+
+interface Document {
+  title: string;
+  url: string;
+  indexed_at: string;
+}
+
+interface SourceDocumentsResponse {
+  documents: Document[];
+  total: number;
+}
+
+const fetchSourceDocuments = async (
+  domain: string,
+  page: number
+): Promise<SourceDocumentsResponse> => {
+  const response = await fetch("/api/elasticSearchProxy/sourceDocuments", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ domain, page }),
+  });
+  const data = await response.json();
+  if (!data.success) throw new Error(data.message);
+  return data.data;
+};
+
+export const useSourceDocuments = (domain: string, page: number) => {
+  const { data, isLoading, isError, error } = useQuery<
+    SourceDocumentsResponse,
+    Error
+  >({
+    queryKey: ["sourceDocuments", domain, page],
+    queryFn: () => fetchSourceDocuments(domain, page),
+    cacheTime: Infinity,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    sourceDocuments: data?.documents,
+    total: data?.total,
+    isLoading,
+    isError,
+    error,
+  };
+};

--- a/src/hooks/useSources.ts
+++ b/src/hooks/useSources.ts
@@ -1,0 +1,45 @@
+import { useQuery } from "@tanstack/react-query";
+import { EsSourcesResponse } from "@/types";
+
+type FetchSources = (url?: string) => Promise<EsSourcesResponse>;
+
+const fetchSources: FetchSources = async (url) => {
+  return fetch(url ?? "/api/elasticSearchProxy/sources", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({}),
+  })
+    .then(async (res) => {
+      const data = await res.json();
+      if (!data.success) {
+        const errMessage = data.message || "Error while fetching sources";
+        throw new Error(errMessage);
+      }
+      return data.data?.result;
+    })
+    .catch((err) => {
+      throw new Error(err.message ?? "Error fetching sources");
+    });
+};
+
+export const useSources = () => {
+  const { data, isLoading, isError, error } = useQuery<
+    EsSourcesResponse,
+    Error
+  >({
+    queryKey: ["sources"],
+    queryFn: () => fetchSources(),
+    cacheTime: Infinity,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    sources: data,
+    isLoading,
+    isError,
+    error,
+  };
+};

--- a/src/pages/api/elasticSearchProxy/getDocumentContent.ts
+++ b/src/pages/api/elasticSearchProxy/getDocumentContent.ts
@@ -1,0 +1,55 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { client } from "@/config/elasticsearch";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({
+      error:
+        "Invalid request method. This endpoint only supports POST requests.",
+    });
+  }
+
+  const { url } = req.body;
+
+  if (!url) {
+    return res.status(400).json({
+      error: "URL is required",
+    });
+  }
+
+  try {
+    const result = await client.search({
+      index: process.env.INDEX,
+      body: {
+        query: {
+          term: { "url.keyword": url },
+        },
+        size: 1,
+      },
+    });
+
+    if (result.hits.hits.length === 0) {
+      return res.status(404).json({
+        success: false,
+        message: "Document not found",
+      });
+    }
+
+    const document = result.hits.hits[0]._source;
+
+    return res.status(200).json({
+      success: true,
+      data: document,
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(400).json({
+      success: false,
+      message:
+        error.message || "An error occurred while fetching document content",
+    });
+  }
+}

--- a/src/pages/api/elasticSearchProxy/sourceDocuments.ts
+++ b/src/pages/api/elasticSearchProxy/sourceDocuments.ts
@@ -1,0 +1,63 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { client } from "@/config/elasticsearch";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({
+      error:
+        "Invalid request method. This endpoint only supports POST requests.",
+    });
+  }
+
+  const { domain, page = 1 } = req.body;
+
+  if (!domain) {
+    return res.status(400).json({
+      error: "Domain is required",
+    });
+  }
+
+  const size = 10;
+  const from = (page - 1) * size;
+
+  try {
+    const result = await client.search({
+      index: process.env.INDEX,
+      body: {
+        from,
+        size,
+        query: {
+          term: { "domain.keyword": domain },
+        },
+        _source: ["title", "url", "indexed_at"],
+        sort: [{ indexed_at: "desc" }],
+      },
+    });
+
+    const documents = result.hits.hits.map((hit) => hit._source);
+
+    // Handle both possible types of total
+    const total =
+      typeof result.hits.total === "number"
+        ? result.hits.total
+        : result.hits.total.value;
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        documents,
+        total,
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(400).json({
+      success: false,
+      message:
+        error.message || "An error occurred while fetching document details",
+    });
+  }
+}

--- a/src/pages/api/elasticSearchProxy/sources.ts
+++ b/src/pages/api/elasticSearchProxy/sources.ts
@@ -1,0 +1,71 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { client } from "@/config/elasticsearch";
+
+interface DomainAggregationBucket {
+  key: string;
+  doc_count: number;
+  last_indexed: {
+    value: number;
+  };
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST") {
+    return res.status(405).json({
+      error:
+        "Invalid request method. This endpoint only supports POST requests.",
+    });
+  }
+
+  try {
+    const result = await client.search({
+      index: process.env.INDEX,
+      body: {
+        size: 0,
+        aggs: {
+          domains: {
+            terms: {
+              field: "domain.keyword",
+              size: 1000, // Adjust based on the expected number of unique domains
+            },
+            aggs: {
+              last_indexed: {
+                max: {
+                  field: "indexed_at",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const domainBuckets = (
+      result.aggregations?.domains as {
+        buckets: DomainAggregationBucket[];
+      }
+    ).buckets;
+
+    const sources = domainBuckets.map((bucket) => ({
+      domain: bucket.key,
+      documentCount: bucket.doc_count,
+      lastScraped: bucket.last_indexed.value || null,
+    }));
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        result: sources,
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(400).json({
+      success: false,
+      message: error.message || "An error occurred while fetching sources data",
+    });
+  }
+}

--- a/src/pages/sources.tsx
+++ b/src/pages/sources.tsx
@@ -1,0 +1,139 @@
+import React, { useState, useMemo } from "react";
+import NavBar from "@/components/navBar/NavBar";
+import Footer from "@/components/footer/Footer";
+import { useSources } from "@/hooks/useSources";
+import { Source } from "@/types";
+
+const formatTimeAgo = (date: string | number) => {
+  const now = new Date();
+  const past = new Date(date);
+  const diffTime = Math.abs(now.getTime() - past.getTime());
+  const diffHours = Math.floor(diffTime / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+
+  if (diffHours < 24) {
+    if (diffHours === 0) return "Less than an hour ago";
+    if (diffHours === 1) return "1 hour ago";
+    return `${diffHours} hours ago`;
+  }
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return `${diffDays} days ago`;
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`;
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)} months ago`;
+  return `${Math.floor(diffDays / 365)} years ago`;
+};
+
+const SourcesPage: React.FC = () => {
+  const { sources, isLoading, isError, error } = useSources();
+  const [sortConfig, setSortConfig] = useState<{
+    key: keyof Source;
+    direction: "ascending" | "descending";
+  } | null>(null);
+
+  const sortedSources = useMemo(() => {
+    if (!sources) return [];
+    const sortableItems = [...sources];
+    if (sortConfig !== null) {
+      sortableItems.sort((a, b) => {
+        if (a[sortConfig.key] < b[sortConfig.key]) {
+          return sortConfig.direction === "ascending" ? -1 : 1;
+        }
+        if (a[sortConfig.key] > b[sortConfig.key]) {
+          return sortConfig.direction === "ascending" ? 1 : -1;
+        }
+        return 0;
+      });
+    }
+    return sortableItems;
+  }, [sources, sortConfig]);
+
+  const sortBy = (key: keyof Source) => {
+    let direction: "ascending" | "descending" = "ascending";
+    if (
+      sortConfig &&
+      sortConfig.key === key &&
+      sortConfig.direction === "ascending"
+    ) {
+      direction = "descending";
+    }
+    setSortConfig({ key, direction });
+  };
+
+  const getSortIndicator = (key: keyof Source) => {
+    if (sortConfig && sortConfig.key === key) {
+      return sortConfig.direction === "ascending" ? " ▲" : " ▼";
+    }
+    return "";
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-custom-background text-custom-primary-text">
+      <NavBar />
+      <main className="flex-grow w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 mt-16">
+        <h1 className="text-2xl font-bold mb-4">Data Sources</h1>
+        {isLoading ? (
+          <div>Loading...</div>
+        ) : isError ? (
+          <div>Error: {error.message}</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full border border-custom-stroke">
+              <thead>
+                <tr className="bg-custom-hover-state dark:bg-custom-hover-primary">
+                  <th
+                    className="px-4 py-2 border-b border-custom-stroke cursor-pointer"
+                    onClick={() => sortBy("domain")}
+                  >
+                    Domain{getSortIndicator("domain")}
+                  </th>
+                  <th
+                    className="px-4 py-2 border-b border-custom-stroke cursor-pointer"
+                    onClick={() => sortBy("lastScraped")}
+                  >
+                    Last Scraped{getSortIndicator("lastScraped")}
+                  </th>
+                  <th
+                    className="px-4 py-2 border-b border-custom-stroke cursor-pointer"
+                    onClick={() => sortBy("documentCount")}
+                  >
+                    Document Count{getSortIndicator("documentCount")}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedSources.map((source, index) => (
+                  <tr
+                    key={index}
+                    className={
+                      index % 2 === 0
+                        ? "bg-custom-hover-state dark:bg-custom-hover-primary"
+                        : "bg-custom-background"
+                    }
+                  >
+                    <td className="px-4 py-2 border-b border-custom-stroke">
+                      {source.domain}
+                    </td>
+                    <td className="px-4 py-2 border-b border-custom-stroke">
+                      <div className="group relative inline-block">
+                        <span>{formatTimeAgo(source.lastScraped)}</span>
+                        <span className="invisible group-hover:visible absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-2 py-1 text-sm bg-custom-black text-custom-white rounded opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap z-10">
+                          {new Date(source.lastScraped).toLocaleString()}
+                        </span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-2 border-b border-custom-stroke">
+                      {source.documentCount}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default SourcesPage;

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,3 +60,11 @@ export type EsSearchResponse = SearchResponse<
   unknown,
   Record<string, AggregationsAggregate>
 >;
+
+export interface Source {
+  domain: string;
+  lastScraped: string;
+  documentCount: number;
+}
+
+export type EsSourcesResponse = Source[];

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,18 @@
+export const formatTimeAgo = (date: string | number) => {
+  const now = new Date();
+  const past = new Date(date);
+  const diffTime = Math.abs(now.getTime() - past.getTime());
+  const diffHours = Math.floor(diffTime / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+
+  if (diffHours < 24) {
+    if (diffHours === 0) return "Less than an hour ago";
+    if (diffHours === 1) return "1 hour ago";
+    return `${diffHours} hours ago`;
+  }
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return `${diffDays} days ago`;
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`;
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)} months ago`;
+  return `${Math.floor(diffDays / 365)} years ago`;
+};


### PR DESCRIPTION
closes #137
This PR implements a new `/sources` page to monitor and manage our data sources, addressing the need for improved data curation and source integration tracking.

### Key Features

1. **Sources Table**: Displays a comprehensive view of our data sources, including:
   - Data source names
   - Last scrape timestamps
   - Document count for each source

2. **Expandable Document View**: Users can quickly preview documents associated with each source directly from the sources table.

3. **Document Content Viewer**: A modal that displays full document details when clicking the view icon, allowing for in-depth inspection of all fields from Elasticsearch.

### Benefits

- Provides a clear overview of our current data sources
- Facilitates easier monitoring of scraping processes
- Enables quick access to document content, improving data quality assessment

### Notes

Currently this page is for internal use, so we don't link to it from anywhere in the application. A possible next step is to utilize this page to streamline the process of integrating and monitoring new data sources.