### PR TITLE
refactor(api): use document ID instead of URL for content fetching

### DIFF
--- a/src/components/sources/DocumentTable.tsx
+++ b/src/components/sources/DocumentTable.tsx
@@ -6,7 +6,7 @@ import { Document } from "@/types";
 interface DocumentTableProps {
   documents: Document[];
   domain: string;
-  onViewDocument: (url: string) => void;
+  onViewDocument: (id: string) => void;
 }
 
 const DocumentTable: React.FC<DocumentTableProps> = ({
@@ -38,7 +38,7 @@ const DocumentTable: React.FC<DocumentTableProps> = ({
       <tbody>
         {documents?.map((doc, index) => (
           <tr
-            key={doc.url}
+            key={doc.id}
             className={
               index % 2 === 0
                 ? "bg-custom-hover-state dark:bg-custom-hover-primary"
@@ -73,7 +73,7 @@ const DocumentTable: React.FC<DocumentTableProps> = ({
             </td>
             <td className="w-10 px-2 py-2 border-b border-custom-stroke text-center">
               <button
-                onClick={() => onViewDocument(doc.url)}
+                onClick={() => onViewDocument(doc.id)}
                 className="text-custom-accent hover:text-custom-accent-dark"
                 title="View document"
               >

--- a/src/components/sources/Documents.tsx
+++ b/src/components/sources/Documents.tsx
@@ -27,7 +27,7 @@ const Documents: React.FC<SourceDocumentsProps> = ({
   const { sourceDocuments, total, isLoading, isError, error } =
     useSourceDocuments(domain, page, viewMode, threadsPage);
 
-  const [selectedDocumentUrl, setSelectedDocumentUrl] = useState<string | null>(
+  const [selectedDocumentId, setSelectedDocumentId] = useState<string | null>(
     null
   );
   const {
@@ -35,7 +35,7 @@ const Documents: React.FC<SourceDocumentsProps> = ({
     isLoading: isContentLoading,
     isError: isContentError,
     error: contentError,
-  } = useDocumentContent(selectedDocumentUrl);
+  } = useDocumentContent(selectedDocumentId);
 
   if (isLoading) return <div>Loading source documents...</div>;
   if (isError)
@@ -67,8 +67,8 @@ const Documents: React.FC<SourceDocumentsProps> = ({
     setExpandedThreads(newExpanded);
   };
 
-  const handleViewDocument = (url: string) => {
-    setSelectedDocumentUrl(url);
+  const handleViewDocument = (id: string) => {
+    setSelectedDocumentId(id);
   };
 
   // Group documents by thread_url for threaded view
@@ -128,8 +128,8 @@ const Documents: React.FC<SourceDocumentsProps> = ({
       />
 
       <DocumentModal
-        isOpen={!!selectedDocumentUrl}
-        onClose={() => setSelectedDocumentUrl(null)}
+        isOpen={!!selectedDocumentId}
+        onClose={() => setSelectedDocumentId(null)}
         document={documentContent}
         isLoading={isContentLoading}
         isError={isContentError}

--- a/src/components/sources/ThreadedDocumentTable.tsx
+++ b/src/components/sources/ThreadedDocumentTable.tsx
@@ -89,7 +89,7 @@ const ThreadedDocumentTable: React.FC<ThreadedDocumentTableProps> = ({
                       <tbody>
                         {docs.map((doc, docIndex) => (
                           <tr
-                            key={doc.url}
+                            key={doc.id}
                             className={
                               docIndex % 2 === 0
                                 ? "bg-custom-hover-state dark:bg-custom-hover-primary"
@@ -116,7 +116,7 @@ const ThreadedDocumentTable: React.FC<ThreadedDocumentTableProps> = ({
                             </td>
                             <td className="w-10 px-2 py-2 text-center">
                               <button
-                                onClick={() => onViewDocument(doc.url)}
+                                onClick={() => onViewDocument(doc.id)}
                                 className="text-custom-accent hover:text-custom-accent-dark"
                                 title="View document"
                               >

--- a/src/hooks/useDocumentContent.ts
+++ b/src/hooks/useDocumentContent.ts
@@ -7,24 +7,24 @@ interface DocumentContent {
   indexed_at: string;
 }
 
-const fetchDocumentContent = async (url: string): Promise<DocumentContent> => {
+const fetchDocumentContent = async (id: string): Promise<DocumentContent> => {
   const response = await fetch("/api/elasticSearchProxy/getDocumentContent", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ url }),
+    body: JSON.stringify({ id }),
   });
   const data = await response.json();
   if (!data.success) throw new Error(data.message);
   return data.data;
 };
 
-export const useDocumentContent = (url: string) => {
+export const useDocumentContent = (id: string | null) => {
   const { data, isLoading, isError, error } = useQuery<DocumentContent, Error>({
-    queryKey: ["documentContent", url],
-    queryFn: () => fetchDocumentContent(url),
-    enabled: !!url,
+    queryKey: ["documentContent", id],
+    queryFn: () => fetchDocumentContent(id),
+    enabled: !!id,
     cacheTime: Infinity,
     staleTime: Infinity,
     refetchOnWindowFocus: false,

--- a/src/pages/api/elasticSearchProxy/getDocumentContent.ts
+++ b/src/pages/api/elasticSearchProxy/getDocumentContent.ts
@@ -12,11 +12,11 @@ export default async function handler(
     });
   }
 
-  const { url } = req.body;
+  const { id } = req.body;
 
-  if (!url) {
+  if (!id) {
     return res.status(400).json({
-      error: "URL is required",
+      error: "Document ID is required",
     });
   }
 
@@ -25,7 +25,7 @@ export default async function handler(
       index: process.env.INDEX,
       body: {
         query: {
-          term: { "url.keyword": url },
+          term: { _id: id },
         },
         size: 1,
       },

--- a/src/pages/api/elasticSearchProxy/sourceDocuments.ts
+++ b/src/pages/api/elasticSearchProxy/sourceDocuments.ts
@@ -128,7 +128,7 @@ export default async function handler(
           }),
           size: 1000,
           sort: [{ indexed_at: "desc" }],
-          _source: ["title", "url", "indexed_at", "thread_url", "type"],
+          _source: ["id", "title", "url", "indexed_at", "thread_url", "type"],
         },
       });
 
@@ -150,7 +150,7 @@ export default async function handler(
           from,
           size,
           query: createQuery(),
-          _source: ["title", "url", "indexed_at", "thread_url", "type"],
+          _source: ["id", "title", "url", "indexed_at", "thread_url", "type"],
           sort: [{ indexed_at: "desc" }],
         },
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,7 @@ export interface Source {
 }
 
 export interface Document {
+  id: string;
   title: string;
   url: string;
   indexed_at: string;


### PR DESCRIPTION
The application was previously using URLs to fetch document content, but URLs are not guaranteed to be unique across documents. Switch to using Elasticsearch document IDs which are guaranteed unique identifiers. Update types, API endpoints, and components to pass document IDs instead of URLs throughout the content fetching flow.